### PR TITLE
Implement 'Z' ANSI sequence

### DIFF
--- a/terminal.cpp
+++ b/terminal.cpp
@@ -789,7 +789,7 @@ void Terminal::ansiSequence(const QString& seq)
         break;
 
     case 'Z': // back tab
-        if(cursorPos().y() > 0) {
+        if(cursorPos().y() > 0 && cursorPos().y() <= iTabStops.size()) {
             for(int i=iTabStops[cursorPos().y()-1].count()-1; i>0; i--) {
                 if(iTabStops[cursorPos().y()-1][i] < cursorPos().x()) {
                     setCursorPos(QPoint( iTabStops[cursorPos().y()-1][i], cursorPos().y() ));

--- a/terminal.cpp
+++ b/terminal.cpp
@@ -788,6 +788,17 @@ void Terminal::ansiSequence(const QString& seq)
         }
         break;
 
+    case 'Z': // back tab
+        if(cursorPos().y() > 0) {
+            for(int i=iTabStops[cursorPos().y()-1].count()-1; i>0; i--) {
+                if(iTabStops[cursorPos().y()-1][i] < cursorPos().x()) {
+                    setCursorPos(QPoint( iTabStops[cursorPos().y()-1][i], cursorPos().y() ));
+                    break;
+                }
+            }
+        }
+        break;
+
     case 'c': // vt100 identification
         if(params.count()==0)
             params.append(0);


### PR DESCRIPTION
This fixes scrolling issues, e.g. editing long lines of text in nano.