### PR TITLE
Fix touch handling with rounded corners

### DIFF
--- a/keyloader.cpp
+++ b/keyloader.cpp
@@ -38,7 +38,7 @@ KeyLoader::~KeyLoader()
 bool KeyLoader::loadLayout(const QString &layout)
 {
     bool ret = false;
-    if(layout.isEmpty() || !iUtil)
+    if (layout.isEmpty() || !iUtil)
         return false;
 
     if (layout.at(0)==':') {  // load from resources
@@ -72,8 +72,7 @@ bool KeyLoader::loadLayoutInternal(QIODevice &from)
     QList<KeyData> keyRow;
     while(!from.atEnd()) {
         QString line = QString::fromUtf8(from.readLine()).simplified();
-        if(line.length()>=2 && line.at(0)!=';' && line.at(0)=='[' && line.at(line.length()-1)==']')
-        {
+        if (line.length() >= 2 && line.at(0) != ';' && line.at(0) == '[' && line.at(line.length() - 1) == ']') {
             KeyData key;
             key.label = "";
             key.code = 0;
@@ -100,19 +99,19 @@ bool KeyLoader::loadLayoutInternal(QIODevice &from)
             line.replace("\\x5C", "\\");
 
             QStringList parts = line.split(",", QString::KeepEmptyParts);
-            if(parts.count()>=2) {
+            if (parts.count() >= 2) {
                 bool ok = true;
                 key.label = parts.at(0);
                 key.label.replace("\\x2C",",");
                 parts[1].replace("0x","");
                 key.code = parts.at(1).toInt(&ok,16);
-                if(!ok) {
+                if (!ok) {
                     ret = false;
                     break;
                 }
-                if(key.code==Qt::AltModifier || key.code==Qt::ControlModifier || key.code==Qt::ShiftModifier)
+                if (key.code == Qt::AltModifier || key.code == Qt::ControlModifier || key.code == Qt::ShiftModifier)
                     key.isModifier = true;
-                if(parts.count()>=4 && !key.isModifier) {
+                if (parts.count() >= 4 && !key.isModifier) {
                     key.label_alt = parts.at(2);
                     key.label_alt.replace("\\x2C",",");
                     parts[3].replace("0x","");
@@ -127,8 +126,8 @@ bool KeyLoader::loadLayoutInternal(QIODevice &from)
             cleanUpKey(key);
             keyRow.append(key);
         }
-        else if(line.length()==0 && lastLineHadKey) {
-            if(keyRow.count() > iVkbColumns) {
+        else if (line.length() == 0 && lastLineHadKey) {
+            if (keyRow.count() > iVkbColumns) {
                 iVkbColumns = keyRow.count();
             }
             iKeyData.append(keyRow);
@@ -139,12 +138,12 @@ bool KeyLoader::loadLayoutInternal(QIODevice &from)
             lastLineHadKey = false;
         }
     }
-    if(keyRow.count() > 0)
+    if (keyRow.count() > 0)
         iKeyData.append(keyRow);
 
     iVkbRows = iKeyData.count();
-    foreach(QList<KeyData> r, iKeyData) {
-        if(r.count() > iVkbColumns)
+    foreach (QList<KeyData> r, iKeyData) {
+        if (r.count() > iVkbColumns)
             iVkbColumns = r.count();
     }
 
@@ -171,9 +170,9 @@ QVariantList KeyLoader::keyAt(int row, int col)
     ret.append(0);  //width
     ret.append(false);  //isModifier
 
-    if(iKeyData.count() <= row)
+    if (iKeyData.count() <= row)
         return ret;
-    if(iKeyData.at(row).count() <= col)
+    if (iKeyData.at(row).count() <= col)
         return ret;
 
     ret[0] = iKeyData.at(row).at(col).label;
@@ -197,14 +196,14 @@ const QStringList KeyLoader::availableLayouts()
     QStringList results = confDir.entryList(filter, QDir::Files|QDir::Readable, QDir::Name);
 
     QStringList ret;
-    foreach(QString s, results) {
+    foreach (QString s, results) {
         ret << s.left(s.lastIndexOf('.'));
     }
 
     // Add also layouts from installation path.
     QDir dataDir(QStringLiteral(DEPLOYMENT_PATH) + "/data");
     results = dataDir.entryList(filter, QDir::Files|QDir::Readable, QDir::Name);
-    foreach(QString s, results) {
+    foreach (QString s, results) {
         QString layout = s.left(s.lastIndexOf('.'));
         if (!ret.contains(layout))
             ret << layout;
@@ -218,13 +217,13 @@ void KeyLoader::cleanUpKey(KeyData &key)
     // make sure that a key does not try to use some (currently) unsupported feature...
 
     // if the label is an image or a modifier, we do not support an alternative label
-    if ((key.label.startsWith(':') && key.label.length()>1) || key.isModifier) {
+    if ((key.label.startsWith(':') && key.label.length() > 1) || key.isModifier) {
         key.label_alt = "";
         key.code_alt = 0;
     }
 
     // if the alternative label is an image (and the default one was not), use it as the (only) default
-    if (key.label_alt.startsWith(':') && key.label_alt.length()>1) {
+    if (key.label_alt.startsWith(':') && key.label_alt.length() > 1) {
         key.label = key.label_alt;
         key.code = key.code_alt;
         key.label_alt = "";
@@ -232,13 +231,13 @@ void KeyLoader::cleanUpKey(KeyData &key)
     }
 
     // alphabet letters can't have an alternative, they just switch between lower and upper case
-    if (key.label.length()==1 && key.label.at(0).isLetter()) {
+    if (key.label.length() == 1 && key.label.at(0).isLetter()) {
         key.label_alt = "";
         key.code_alt = 0;
     }
 
     // ... also, can't have alphabet letters as an alternative label
-    if (key.label_alt.length()==1 && key.label_alt.at(0).isLetter()) {
+    if (key.label_alt.length() == 1 && key.label_alt.at(0).isLetter()) {
         key.label_alt = "";
         key.code_alt = 0;
     }

--- a/main.cpp
+++ b/main.cpp
@@ -62,15 +62,15 @@ int main(int argc, char *argv[])
     if (pid == -1) {
         qWarning("forkpty failed");
         exit(1);
-    } else if( pid==0 ) {
+    } else if (pid == 0) {
         setenv("TERM", settings->value("terminal/envVarTERM", "xterm").toByteArray(), 1);
 
         QString execCmd;
-        for(int i=0; i<argc-1; i++) {
-            if( QString(argv[i]) == "-e" )
+        for (int i=0; i<argc-1; i++) {
+            if (QString(argv[i]) == "-e")
                 execCmd = QString(argv[i+1]);
         }
-        if(execCmd.isEmpty()) {
+        if (execCmd.isEmpty()) {
             execCmd = settings->value("general/execCmd").toString();
         }
 
@@ -98,7 +98,7 @@ int main(int argc, char *argv[])
     app.installTranslator(translator.data());
 
     QScreen* sc = app.primaryScreen();
-    if(sc){
+    if (sc) {
         QFlags<Qt::ScreenOrientation> mask = Qt::PrimaryOrientation
                 | Qt::PortraitOrientation
                 | Qt::LandscapeOrientation
@@ -136,20 +136,22 @@ int main(int argc, char *argv[])
     KeyLoader keyLoader;
     keyLoader.setUtil(&util);
     bool ret = keyLoader.loadLayout(util.keyboardLayout());
-    if(!ret) {
+    if (!ret) {
         // on failure, try to load the default one (english) directly from resources
         startupErrorMsg = "There was an error loading the keyboard layout.<br>\nUsing the default one instead.";
         util.setKeyboardLayout("english");
         ret = keyLoader.loadLayout(":/data/english.layout");
-        if(!ret)
-            qFatal("failure loading keyboard layout");
+        if (!ret) {
+            qWarning("failure loading keyboard layout");
+            return 1;
+        }
     }
 
     QQmlContext *context = view.rootContext();
-    context->setContextProperty( "term", &term );
-    context->setContextProperty( "util", &util );
-    context->setContextProperty( "keyLoader", &keyLoader );
-    context->setContextProperty( "startupErrorMessage", startupErrorMsg);
+    context->setContextProperty("term", &term);
+    context->setContextProperty("util", &util);
+    context->setContextProperty("keyLoader", &keyLoader);
+    context->setContextProperty("startupErrorMessage", startupErrorMsg);
 
     term.setWindow(&view);
     util.setWindow(&view);

--- a/main.cpp
+++ b/main.cpp
@@ -59,8 +59,8 @@ int main(int argc, char *argv[])
     // fork the child process before creating QGuiApplication
     int socketM;
     int pid = forkpty(&socketM,NULL,NULL,NULL);
-    if( pid==-1 ) {
-        qFatal("forkpty failed");
+    if (pid == -1) {
+        qWarning("forkpty failed");
         exit(1);
     } else if( pid==0 ) {
         setenv("TERM", settings->value("terminal/envVarTERM", "xterm").toByteArray(), 1);
@@ -162,8 +162,10 @@ int main(int argc, char *argv[])
     view.setSource(QUrl::fromLocalFile(QStringLiteral(DEPLOYMENT_PATH) + QDir::separator() + QStringLiteral("Main.qml")));
 
     QObject *root = view.rootObject();
-    if(!root)
-        qFatal("no root object - qml error");
+    if (!root) {
+        qWarning("no root object - qml error, exiting");
+        return 1;
+    }
 
     if (fullscreen) {
         view.showFullScreen();
@@ -173,8 +175,10 @@ int main(int argc, char *argv[])
 
     PtyIFace ptyiface(pid, socketM, &term, util.charset());
 
-    if( ptyiface.failed() )
-        qFatal("pty failure");
+    if (ptyiface.failed()) {
+        qWarning("pty failure, exiting");
+        return 1;
+    }
 
     return app.exec();
 }

--- a/ptyiface.cpp
+++ b/ptyiface.cpp
@@ -39,10 +39,10 @@ static int childProcessPid = 0;
 
 void sighandler(int sig)
 {
-    if(sig==SIGCHLD) {
+    if (sig==SIGCHLD) {
         int pid = wait(NULL);
 
-        if(pid > 0 && childProcessPid > 0 &&  pid==childProcessPid) {
+        if (pid > 0 && childProcessPid > 0 &&  pid==childProcessPid) {
             childProcessQuit = true;
             childProcessPid = 0;
             qApp->quit();
@@ -61,7 +61,7 @@ PtyIFace::PtyIFace(int pid, int masterFd, Terminal *term, QString charset, QObje
 {
     childProcessPid = iPid;
 
-    if(!iTerm || childProcessQuit) {
+    if (!iTerm || childProcessQuit) {
         iFailed = true;
         qFatal("PtyIFace: null Terminal pointer");
     }
@@ -69,10 +69,10 @@ PtyIFace::PtyIFace(int pid, int masterFd, Terminal *term, QString charset, QObje
     iTerm->setPtyIFace(this);
 
     resize(iTerm->rows(), iTerm->columns());
-    connect(iTerm,SIGNAL(termSizeChanged(int,int)),this,SLOT(resize(int,int)));
+    connect(iTerm, SIGNAL(termSizeChanged(int,int)), this, SLOT(resize(int,int)));
 
     iReadNotifier = new QSocketNotifier(iMasterFd, QSocketNotifier::Read, this);
-    connect(iReadNotifier,SIGNAL(activated(int)),this,SLOT(readActivated()));
+    connect(iReadNotifier, SIGNAL(activated(int)), this, SLOT(readActivated()));
 
     signal(SIGCHLD,&sighandler);
     fcntl(iMasterFd, F_SETFL, O_NONBLOCK); // reads from the descriptor should be non-blocking
@@ -87,7 +87,7 @@ PtyIFace::PtyIFace(int pid, int masterFd, Terminal *term, QString charset, QObje
 
 PtyIFace::~PtyIFace()
 {
-    if(!childProcessQuit) {
+    if (!childProcessQuit) {
         // make the process quit
         kill(iPid, SIGHUP);
         kill(iPid, SIGTERM);
@@ -100,13 +100,13 @@ void PtyIFace::readActivated()
 {
     QByteArray data;
     readTerm(data);
-    if(iTerm)
-        iTerm->insertInBuffer( iTextCodec->toUnicode(data) );
+    if (iTerm)
+        iTerm->insertInBuffer(iTextCodec->toUnicode(data));
 }
 
 void PtyIFace::resize(int rows, int columns)
 {
-    if(childProcessQuit)
+    if (childProcessQuit)
         return;
 
     winsize winp;
@@ -118,29 +118,29 @@ void PtyIFace::resize(int rows, int columns)
 
 void PtyIFace::writeTerm(const QString &chars)
 {
-    writeTerm( iTextCodec->fromUnicode(chars) );
+    writeTerm(iTextCodec->fromUnicode(chars));
 }
 
 void PtyIFace::writeTerm(const QByteArray &chars)
 {
-    if(childProcessQuit)
+    if (childProcessQuit)
         return;
 
     int ret = write(iMasterFd, chars, chars.size());
-    if(ret != chars.size())
+    if (ret != chars.size())
         qDebug() << "write error!";
 }
 
 void PtyIFace::readTerm(QByteArray &chars)
 {
-    if(childProcessQuit)
+    if (childProcessQuit)
         return;
 
     int ret = 0;
     char ch[64];
     while(ret != -1) {
         ret = read(iMasterFd, &ch, 64);
-        if(ret > 0)
+        if (ret > 0)
             chars.append((char*)&ch, ret);
     }
 }

--- a/qml/Button.qml
+++ b/qml/Button.qml
@@ -56,6 +56,7 @@ Rectangle {
 
     Text {
         id: title
+
         text: button.text
         color: !button.enabled ? "#606060"
                                : btnMouseArea.pressed ? "#000000"

--- a/qml/Key.qml
+++ b/qml/Key.qml
@@ -48,6 +48,7 @@ Rectangle {
 
     Image {
         id: keyImage
+
         anchors.centerIn: parent
         opacity: key.labelOpacity
         source: {
@@ -65,6 +66,7 @@ Rectangle {
 
         Text {
             id: keyAltLabel
+
             property bool highlighted: key.isAltCurrent
 
             anchors.horizontalCenter: parent.horizontalCenter

--- a/qml/Keyboard.qml
+++ b/qml/Keyboard.qml
@@ -49,17 +49,19 @@ Item {
         id: keyboardContents
 
         Column {
-            id: col
-
-            x: (keyboard.width - width) / 2
             spacing: keyboard.keyspacing
+            width: parent.width
 
             Repeater {
                 id: rowRepeater
 
                 model: keyLoader.vkbRows
+                width: parent.width
+
                 delegate: Row {
+                    anchors.horizontalCenter: parent.horizontalCenter
                     spacing: keyboard.keyspacing
+
                     Repeater {
                         id: colRepeater
 
@@ -82,6 +84,8 @@ Item {
 
     Loader {
         id: keyboardLoader
+
+        width: parent.width
     }
 
     Component.onCompleted: {

--- a/qml/Keyboard.qml
+++ b/qml/Keyboard.qml
@@ -108,6 +108,7 @@ Item {
 
         Text {
             id: label
+
             color: keyBgColor
             font.pointSize: 34*window.pixelRatio
             anchors.centerIn: parent

--- a/terminal.cpp
+++ b/terminal.cpp
@@ -63,7 +63,7 @@ Terminal::Terminal(QObject *parent) :
 void Terminal::setPtyIFace(PtyIFace *pty)
 {
     iPtyIFace = pty;
-    if(!pty) {
+    if (!pty) {
         qDebug() << "warning: null pty iface";
     }
 }
@@ -82,25 +82,25 @@ TermChar Terminal::zeroChar() const
 
 void Terminal::setCursorPos(QPoint pos)
 {
-    if( iTermAttribs.cursorPos != pos ) {
+    if (iTermAttribs.cursorPos != pos) {
         int tlimit = 1;
         int blimit = iTermSize.height();
-        if(iTermAttribs.originMode) {
+        if (iTermAttribs.originMode) {
             tlimit = iMarginTop;
             blimit = iMarginBottom;
         }
 
-        if(pos.x() < 1)
+        if (pos.x() < 1)
             pos.setX(1);
-        if(pos.x() > iTermSize.width()+1)
-            pos.setX(iTermSize.width()+1);
-        if(pos.y() < tlimit)
+        if (pos.x() > iTermSize.width() + 1)
+            pos.setX(iTermSize.width() + 1);
+        if (pos.y() < tlimit)
             pos.setY(tlimit);
-        if(pos.y() > blimit)
+        if (pos.y() > blimit)
             pos.setY(blimit);
 
-        iTermAttribs.cursorPos=pos;
-        if(iEmitCursorChangeSignal)
+        iTermAttribs.cursorPos = pos;
+        if (iEmitCursorChangeSignal)
             emit cursorPosChanged(pos);
     }
 }
@@ -112,7 +112,7 @@ QPoint Terminal::cursorPos()
 
 bool Terminal::showCursor()
 {
-    if(iBackBufferScrollPos != 0)
+    if (iBackBufferScrollPos != 0)
         return false;
 
     return iShowCursor;
@@ -120,7 +120,7 @@ bool Terminal::showCursor()
 
 QList<TermLine>& Terminal::buffer()
 {
-    if(iUseAltScreenBuffer)
+    if (iUseAltScreenBuffer)
         return iAltBuffer;
 
     return iBuffer;
@@ -128,7 +128,7 @@ QList<TermLine>& Terminal::buffer()
 
 void Terminal::setTermSize(QSize size)
 {
-    if( iTermSize != size ) {
+    if (iTermSize != size) {
         iMarginTop = 1;
         iMarginBottom = size.height();
         iTermSize=size;
@@ -149,33 +149,33 @@ void Terminal::putString(QString str, bool unEscape)
         str.replace("\\t", "\t");
 
         //hex
-        while(str.indexOf("\\x") != -1) {
+        while (str.indexOf("\\x") != -1) {
             int i = str.indexOf("\\x")+2;
             QString num;
-            while(num.length() < 2 && str.length()>i && charIsHexDigit(str.at(i))) {
+            while (num.length() < 2 && str.length() > i && charIsHexDigit(str.at(i))) {
                 num.append(str.at(i));
                 i++;
             }
-            str.remove(i-2-num.length(), num.length()+2);
+            str.remove(i - 2 - num.length(), num.length() + 2);
             bool ok;
-            str.insert(i-2-num.length(), QChar(num.toInt(&ok,16)));
+            str.insert(i - 2 - num.length(), QChar(num.toInt(&ok, 16)));
         }
         //octal
-        while(str.indexOf("\\0") != -1) {
-            int i = str.indexOf("\\0")+2;
+        while (str.indexOf("\\0") != -1) {
+            int i = str.indexOf("\\0") + 2;
             QString num;
-            while(num.length() < 3 && str.length()>i &&
-                  (str.at(i).toLatin1() >= 48 && str.at(i).toLatin1() <= 55)) { //accept only 0-7
+            while(num.length() < 3 && str.length()>i
+                  && (str.at(i).toLatin1() >= 48 && str.at(i).toLatin1() <= 55)) { //accept only 0-7
                 num.append(str.at(i));
                 i++;
             }
-            str.remove(i-2-num.length(), num.length()+2);
+            str.remove(i - 2 - num.length(), num.length() + 2);
             bool ok;
-            str.insert(i-2-num.length(), QChar(num.toInt(&ok,8)));
+            str.insert(i - 2 - num.length(), QChar(num.toInt(&ok, 8)));
         }
     }
 
-    if(iPtyIFace)
+    if (iPtyIFace)
         iPtyIFace->writeTerm(str);
 }
 
@@ -1339,12 +1339,12 @@ const QStringList Terminal::grabURLsFromBuffer()
 
     foreach(QString prot, lookFor) {
         int ind=0;
-        while( ind != -1 ) {
+        while (ind != -1) {
             ind = buf.indexOf(prot, ind);
-            if(ind!=-1) {
+            if (ind!=-1) {
                 int ind2 = buf.indexOf(" ",ind);
                 int l=-1;
-                if(ind2!=-1)
+                if (ind2 != -1)
                     l = ind2-ind;
                 ret << buf.mid(ind,l); // the URL
                 ind += prot.length();
@@ -1372,13 +1372,13 @@ QString Terminal::getUserMenuXml()
 
 void Terminal::scrollBackBufferFwd(int lines)
 {
-    if(iUseAltScreenBuffer || lines<=0)
+    if (iUseAltScreenBuffer || lines<=0)
         return;
 
     clearSelection();
 
     iBackBufferScrollPos -= lines;
-    if(iBackBufferScrollPos < 0)
+    if (iBackBufferScrollPos < 0)
         iBackBufferScrollPos = 0;
 
     emit scrollBackBufferAdjusted(false);
@@ -1400,7 +1400,7 @@ void Terminal::scrollBackBufferBack(int lines)
 
 void Terminal::resetBackBufferScrollPos()
 {
-    if(iBackBufferScrollPos==0 && iSelection.isNull())
+    if (iBackBufferScrollPos==0 && iSelection.isNull())
         return;
 
     iBackBufferScrollPos = 0;

--- a/textrender.cpp
+++ b/textrender.cpp
@@ -32,9 +32,9 @@ TextRender::TextRender(QQuickItem *parent) :
 {
     setFlag(ItemHasContents);
 
-    connect(this,SIGNAL(widthChanged()),this,SLOT(updateTermSize()));
-    connect(this,SIGNAL(heightChanged()),this,SLOT(updateTermSize()));
-    connect(this,SIGNAL(fontSizeChanged()),this,SLOT(updateTermSize()));
+    connect(this, SIGNAL(widthChanged()), this, SLOT(updateTermSize()));
+    connect(this, SIGNAL(heightChanged()), this, SLOT(updateTermSize()));
+    connect(this, SIGNAL(fontSizeChanged()), this, SLOT(updateTermSize()));
 
     //normal
     iColorTable.append(QColor(0, 0, 0));
@@ -107,12 +107,12 @@ void TextRender::paint(QPainter* painter)
         if(from<0)
             from=0;
         int to = sTerm->backBuffer().size();
-        if(to-from > sTerm->rows())
+        if (to-from > sTerm->rows())
             to = from + sTerm->rows();
         paintFromBuffer(painter, sTerm->backBuffer(), from, to, y);
-        if(to-from < sTerm->rows() && sTerm->buffer().size()>0) {
+        if (to-from < sTerm->rows() && sTerm->buffer().size()>0) {
             int to2 = sTerm->rows() - (to-from);
-            if(to2 > sTerm->buffer().size())
+            if (to2 > sTerm->buffer().size())
                 to2 = sTerm->buffer().size();
             paintFromBuffer(painter, sTerm->buffer(), 0, to2, y);
         }
@@ -173,10 +173,10 @@ void TextRender::paintFromBuffer(QPainter* painter, QList<TermLine>& buffer, int
     TermChar nextAttrib = sTerm->zeroChar();
     TermChar currAttrib = sTerm->zeroChar();
     int currentX = leftmargin;
-    for(int i=from; i<to; i++) {
+    for (int i=from; i<to; i++) {
         y += iFontHeight;
 
-        if(y >= cutAfter)
+        if (y >= cutAfter)
             painter->setOpacity(0.3);
         else
             painter->setOpacity(1.0);
@@ -186,7 +186,7 @@ void TextRender::paintFromBuffer(QPainter* painter, QList<TermLine>& buffer, int
         // background for the current line
         currentX = leftmargin;
         int fragWidth = 0;
-        for(int j=0; j<xcount; j++) {
+        for (int j=0; j<xcount; j++) {
             TermChar tmp = buffer[i][j];
             fragWidth += iFontWidth;
             if (j==0) {
@@ -272,9 +272,9 @@ void TextRender::drawTextFragment(QPainter* painter, int x, int y, QString text,
     if (style.attrib & attribBold) {
         iFont.setBold(true);
         painter->setFont(iFont);
-        if(style.fgColor < 8)
+        if (style.fgColor < 8)
             style.fgColor += 8;
-    } else if(iFont.bold()) {
+    } else if (iFont.bold()) {
         iFont.setBold(false);
         painter->setFont(iFont);
     }
@@ -321,10 +321,10 @@ void TextRender::mouseMove(float eventX, float eventY)
     if (!allowGestures())
         return;
 
-    if(sUtil->dragMode() == Util::DragScroll) {
+    if (sUtil->dragMode() == Util::DragScroll) {
         dragOrigin = scrollBackBuffer(eventPos, dragOrigin);
     }
-    else if(sUtil->dragMode() == Util::DragSelect) {
+    else if (sUtil->dragMode() == Util::DragSelect) {
         selectionHelper(eventPos, true);
     }
 }
@@ -337,22 +337,22 @@ void TextRender::mouseRelease(float eventX, float eventY)
     if (!allowGestures())
         return;
 
-    if(sUtil->dragMode() == Util::DragGestures) {
+    if (sUtil->dragMode() == Util::DragGestures) {
         int xdist = qAbs(eventPos.x() - dragOrigin.x());
         int ydist = qAbs(eventPos.y() - dragOrigin.y());
-        if(eventPos.x() < dragOrigin.x()-reqDragLength && xdist > ydist*2)
+        if (eventPos.x() < dragOrigin.x()-reqDragLength && xdist > ydist*2)
             doGesture(PanLeft);
-        else if(eventPos.x() > dragOrigin.x()+reqDragLength && xdist > ydist*2)
+        else if (eventPos.x() > dragOrigin.x()+reqDragLength && xdist > ydist*2)
             doGesture(PanRight);
-        else if(eventPos.y() > dragOrigin.y()+reqDragLength && ydist > xdist*2)
+        else if (eventPos.y() > dragOrigin.y()+reqDragLength && ydist > xdist*2)
             doGesture(PanDown);
-        else if(eventPos.y() < dragOrigin.y()-reqDragLength && ydist > xdist*2)
+        else if (eventPos.y() < dragOrigin.y()-reqDragLength && ydist > xdist*2)
             doGesture(PanUp);
     }
-    else if(sUtil->dragMode() == Util::DragScroll) {
+    else if (sUtil->dragMode() == Util::DragScroll) {
         scrollBackBuffer(eventPos, dragOrigin);
     }
-    else if(sUtil->dragMode() == Util::DragSelect) {
+    else if (sUtil->dragMode() == Util::DragSelect) {
         selectionHelper(eventPos, false);
     }
 }
@@ -439,10 +439,10 @@ QPointF TextRender::scrollBackBuffer(QPointF now, QPointF last)
 
     int lines = ydist / fontSize;
 
-    if(lines > 0 && now.y() < last.y() && xdist < ydist*2) {
+    if (lines > 0 && now.y() < last.y() && xdist < ydist*2) {
         sTerm->scrollBackBufferFwd(lines);
         last = QPointF(now.x(), last.y() - lines * fontSize);
-    } else if(lines > 0 && now.y() > last.y() && xdist < ydist*2) {
+    } else if (lines > 0 && now.y() > last.y() && xdist < ydist*2) {
         sTerm->scrollBackBufferBack(lines);
         last = QPointF(now.x(), last.y() + lines * fontSize);
     }
@@ -457,19 +457,19 @@ void TextRender::scrollToEnd()
 
 void TextRender::doGesture(PanGesture gesture)
 {
-    if( gesture==PanLeft ) {
+    if (gesture==PanLeft) {
         sUtil->notifyText(sUtil->settingsValue("gestures/panLeftTitle", "Alt-Right").toString());
         sTerm->putString(sUtil->settingsValue("gestures/panLeftCommand", "\\e\\e[C").toString(), true);
     }
-    else if( gesture==PanRight ) {
+    else if (gesture==PanRight) {
         sUtil->notifyText(sUtil->settingsValue("gestures/panRightTitle", "Alt-Left").toString());
         sTerm->putString(sUtil->settingsValue("gestures/panRightCommand", "\\e\\e[D").toString(), true);
     }
-    else if( gesture==PanDown ) {
+    else if (gesture==PanDown) {
         sUtil->notifyText(sUtil->settingsValue("gestures/panDownTitle", "Page Up").toString());
         sTerm->putString(sUtil->settingsValue("gestures/panDownCommand", "\\e[5~").toString(), true);
     }
-    else if( gesture==PanUp ) {
+    else if (gesture==PanUp) {
         sUtil->notifyText(sUtil->settingsValue("gestures/panUpTitle", "Page Down").toString());
         sTerm->putString(sUtil->settingsValue("gestures/panUpCommand", "\\e[6~").toString(), true);
     }

--- a/util.cpp
+++ b/util.cpp
@@ -107,7 +107,7 @@ void Util::openNewWindow()
 
 QString Util::configPath()
 {
-    if(!iSettings)
+    if (!iSettings)
         return QString();
 
     QFileInfo f(iSettings->fileName());
@@ -116,7 +116,7 @@ QString Util::configPath()
 
 QVariant Util::settingsValue(QString key, const QVariant &defaultValue)
 {
-    if(!iSettings)
+    if (!iSettings)
         return defaultValue;
 
     return iSettings->value(key, defaultValue);
@@ -124,7 +124,7 @@ QVariant Util::settingsValue(QString key, const QVariant &defaultValue)
 
 void Util::setSettingsValue(QString key, QVariant value)
 {
-    if(iSettings)
+    if (iSettings)
         iSettings->setValue(key, value);
 }
 
@@ -165,10 +165,10 @@ void Util::keyPressFeedback()
 
 void Util::bellAlert()
 {
-    if(!iWindow)
+    if (!iWindow)
         return;
 
-    if( settingsValue("general/visualBell", true).toBool() ) {
+    if (settingsValue("general/visualBell", true).toBool()) {
         emit visualBell();
     }
 }


### PR DESCRIPTION
Main commit

    Beyond me how touch handling worked here to begin with.
    The keyboard content row column didn't have width set, nor did the Loader
    parent for it so it was working by luck.

Made main() also avoid qFatal() which was making the app do abort and core dump on qml error. Seemed excessive.

And threw in some code style adjustments. Not fixing everything by any means but maybe again a bit more consistent.