### PR TITLE
Margin fixes for rounded corners

### DIFF
--- a/keyloader.cpp
+++ b/keyloader.cpp
@@ -66,7 +66,7 @@ bool KeyLoader::loadLayoutInternal(QIODevice &from)
     iVkbColumns = 0;
     bool lastLineHadKey = false;
 
-    if( !from.open(QIODevice::ReadOnly | QIODevice::Text) )
+    if (!from.open(QIODevice::ReadOnly | QIODevice::Text))
         return false;
 
     QList<KeyData> keyRow;
@@ -116,7 +116,7 @@ bool KeyLoader::loadLayoutInternal(QIODevice &from)
                     key.label_alt.replace("\\x2C",",");
                     parts[3].replace("0x","");
                     key.code_alt = parts.at(3).toInt(&ok,16);
-                    if(!ok) {
+                    if (!ok) {
                         ret = false;
                         break;
                     }

--- a/qml/AboutWindow.qml
+++ b/qml/AboutWindow.qml
@@ -36,15 +36,15 @@ NotifyWin {
         //% "Charset:"
         var charSet = qsTrId("fingerterm-about_la_charset")
 
-
         var str = "<font size=\"+3\">" + title + " " + util.versionString() + "</font><br>\n" +
                 "<font size=\"+1\">" +
                 author + " Heikki Holstila &lt;<a href=\"mailto:heikki.holstila@gmail.com?subject=FingerTerm\">heikki.holstila@gmail.com</a>&gt;<br><br>\n\n" +
                 configFiles + "<br>\n" +
                 util.configPath() + "/<br><br>\n" +
-                sourceCode + "<br>\n<a href=\"https://git.sailfishos.org/mer-core/fingerterm/\">https://git.sailfishos.org/mer-core/fingerterm/</a>"
+                sourceCode + "<br>\n<a href=\"https://github.com/sailfishos/fingerterm/\">https://github.com/sailfishos/fingerterm/</a>"
         if (term.rows != 0 && term.columns != 0) {
-            str += "<br><br>" + windowTitle + " <font color=\"gray\">" + util.windowTitle.substring(0,40) + "</font>" //cut long window title
+            str += "<br><br>" + windowTitle + " <font color=\"gray\">" + util.windowTitle.substring(0, 40)
+                    + "</font>" //cut long window title
             if (util.windowTitle.length > 40)
                 str += "..."
             str += "<br>" + terminalSize + " <font color=\"gray\">" + term.columns + "×" + term.rows + "</font>"

--- a/qml/Lineview.qml
+++ b/qml/Lineview.qml
@@ -44,6 +44,7 @@ Rectangle {
 
     Text {
         id: fontHeightHack
+
         visible: false
         text: "X"
         font.family: util.fontFamily

--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -403,12 +403,12 @@ Item {
             function _applyKeyboardOffset() {
                 if (vkb.active) {
                     var move = textrender.cursorPixelPos().y + textrender.fontHeight/2
-                            + textrender.fontHeight*util.extraLinesFromCursor
-                    if (move < vkb.y) {
+                            + textrender.fontHeight * util.extraLinesFromCursor
+                    if ((textrender.baseY + move) < vkb.y) {
                         textrender.y = textrender.baseY
                         textrender.cutAfter = vkb.y
                     } else {
-                        textrender.y = textrender.baseY - move + vkb.y
+                        textrender.y = 0 - move + vkb.y
                         textrender.cutAfter = move
                     }
                 } else {

--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -268,7 +268,7 @@ Item {
 
                 y: baseY
                 x: !page.portrait ? page.cornerRounding : 0
-                height: parent.height - (util.keyboardMode == Util.KeyboardFixed ? vkb.height : 0) - 2*baseY
+                height: parent.height - (util.keyboardMode == Util.KeyboardFixed ? vkb.height : baseY) - baseY
                 width: parent.width - 2*x
                 fontPointSize: util.fontSize
                 opacity: (util.keyboardMode == Util.KeyboardFade && vkb.active) ? 0.3

--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -436,18 +436,17 @@ Item {
                 setTextRenderAttributes()
             }
 
+            function showErrorMessage(string) {
+                errorDialog.text = "<font size=\"+2\">" + string + "</font>"
+                errorDialog.show = true
+            }
+
             Component.onCompleted: {
                 if (util.showWelcomeScreen)
                     aboutDialog.show = true
                 if (startupErrorMessage != "") {
                     showErrorMessage(startupErrorMessage)
                 }
-            }
-
-            function showErrorMessage(string)
-            {
-                errorDialog.text = "<font size=\"+2\">" + string + "</font>"
-                errorDialog.show = true
             }
         }
     }

--- a/rpm/fingerterm.spec
+++ b/rpm/fingerterm.spec
@@ -1,5 +1,5 @@
 Name: fingerterm
-Version: 1.3.12
+Version: 1.4.10
 Release: 1
 Summary: A terminal emulator with a custom virtual keyboard
 License: GPLv2

--- a/textrender.cpp
+++ b/textrender.cpp
@@ -25,10 +25,10 @@
 Terminal* TextRender::sTerm = 0;
 Util* TextRender::sUtil = 0;
 
-TextRender::TextRender(QQuickItem *parent) :
-    QQuickPaintedItem(parent),
-    newSelection(true),
-    iAllowGestures(true)
+TextRender::TextRender(QQuickItem *parent)
+    : QQuickPaintedItem(parent)
+    , newSelection(true)
+    , iAllowGestures(true)
 {
     setFlag(ItemHasContents);
 
@@ -70,7 +70,7 @@ TextRender::TextRender(QQuickItem *parent) :
     for (int i = 0; i < 24; i++)
         iColorTable.append(QColor(ramp[i], ramp[i], ramp[i]));
 
-    if(iColorTable.size() != 256)
+    if (iColorTable.size() != 256)
         qFatal("invalid color table");
 
     iShowBufferScrollIndicator = false;
@@ -102,9 +102,9 @@ void TextRender::paint(QPainter* painter)
     painter->setFont(iFont);
 
     int y=0;
-    if (sTerm->backBufferScrollPos() != 0 && sTerm->backBuffer().size()>0) {
+    if (sTerm->backBufferScrollPos() != 0 && sTerm->backBuffer().size() > 0) {
         int from = sTerm->backBuffer().size() - sTerm->backBufferScrollPos();
-        if(from<0)
+        if (from<0)
             from=0;
         int to = sTerm->backBuffer().size();
         if (to-from > sTerm->rows())
@@ -196,11 +196,10 @@ void TextRender::paintFromBuffer(QPainter* painter, QList<TermLine>& buffer, int
                 nextAttrib = buffer[i][j+1];
             }
 
-            if (currAttrib.attrib != nextAttrib.attrib ||
-                currAttrib.bgColor != nextAttrib.bgColor ||
-                currAttrib.fgColor != nextAttrib.fgColor ||
-                j==xcount-1)
-            {
+            if (currAttrib.attrib != nextAttrib.attrib
+                    || currAttrib.bgColor != nextAttrib.bgColor
+                    || currAttrib.fgColor != nextAttrib.fgColor
+                    || j == xcount - 1) {
                 drawBgFragment(painter, currentX, y-iFontHeight+iFontDescent, fragWidth, currAttrib);
                 currentX += fragWidth;
                 fragWidth = 0;
@@ -214,29 +213,29 @@ void TextRender::paintFromBuffer(QPainter* painter, QList<TermLine>& buffer, int
             eol.fgColor = buffer[i].fgColor;
             eol.bgColor = buffer[i].bgColor;
             eol.attrib = buffer[i].attrib;
-            drawBgFragment(painter, currentX, y-iFontHeight+iFontDescent, sTerm->columns() * iFontWidth - currentX, eol);
+            drawBgFragment(painter, currentX, y - iFontHeight + iFontDescent,
+                           sTerm->columns() * iFontWidth - currentX, eol);
         }
 
         // text for the current line
         QString line;
         currentX = leftmargin;
-        for (int j=0; j<xcount; j++) {
+        for (int j = 0; j < xcount; j++) {
             TermChar tmp = buffer[i][j];
             line += tmp.c;
-            if (j==0) {
+            if (j == 0) {
                 currAttrib = tmp;
                 nextAttrib = tmp;
-            } else if(j<xcount-1) {
+            } else if (j < xcount - 1) {
                 nextAttrib = buffer[i][j+1];
             }
 
-            if (currAttrib.attrib != nextAttrib.attrib ||
-                currAttrib.bgColor != nextAttrib.bgColor ||
-                currAttrib.fgColor != nextAttrib.fgColor ||
-                j==xcount-1)
-            {
+            if (currAttrib.attrib != nextAttrib.attrib
+                    || currAttrib.bgColor != nextAttrib.bgColor
+                    || currAttrib.fgColor != nextAttrib.fgColor
+                    || j == xcount - 1) {
                 drawTextFragment(painter, currentX, y, line, currAttrib);
-                currentX += iFontWidth*line.length();
+                currentX += iFontWidth * line.length();
                 line.clear();
                 currAttrib.attrib = nextAttrib.attrib;
                 currAttrib.bgColor = nextAttrib.bgColor;
@@ -409,8 +408,8 @@ QPoint TextRender::cursorPixelPos()
 
 QPoint TextRender::charsToPixels(QPoint pos)
 {
-    // not 100% accurrate with all fonts
-    return QPoint(2+(pos.x()-1)*iFontWidth, (pos.y()-1)*iFontHeight+iFontDescent+1);
+    // not 100% accurate with all fonts
+    return QPoint(2 + (pos.x() - 1) * iFontWidth, (pos.y() - 1) * iFontHeight + iFontDescent + 1);
 }
 
 QSize TextRender::cursorPixelSize()

--- a/util.cpp
+++ b/util.cpp
@@ -34,12 +34,12 @@
 #include <QFeedbackEffect>
 #endif
 
-Util::Util(QSettings *settings, QObject *parent) :
-    QObject(parent),
-    iSettings(settings),
-    iWindow(0),
-    iTerm(0),
-    iKeyboardMode(KeyboardOff)
+Util::Util(QSettings *settings, QObject *parent)
+    : QObject(parent)
+    , iSettings(settings)
+    , iWindow(0)
+    , iTerm(0)
+    , iKeyboardMode(KeyboardOff)
 {
     connect(QGuiApplication::clipboard(), SIGNAL(dataChanged()), this, SIGNAL(clipboardOrSelectionChanged()));
 }
@@ -54,9 +54,10 @@ void Util::setWindow(QQuickView* win)
     if (iWindow)
         qFatal("Should set window property only once");
     iWindow = win;
-    if(!iWindow)
+    if (!iWindow)
         qFatal("invalid main window");
-    connect(win, SIGNAL(contentOrientationChanged(Qt::ScreenOrientation)), this, SLOT(contentOrientationChanged(Qt::ScreenOrientation)));
+    connect(win, SIGNAL(contentOrientationChanged(Qt::ScreenOrientation)),
+            this, SLOT(contentOrientationChanged(Qt::ScreenOrientation)));
 }
 
 void Util::setWindowTitle(QString title)
@@ -155,7 +156,7 @@ void Util::setFontSize(int size)
 
 void Util::keyPressFeedback()
 {
-    if( !settingsValue("ui/keyPressFeedback", true).toBool() )
+    if (!settingsValue("ui/keyPressFeedback", true).toBool())
         return;
 
 #ifdef HAVE_FEEDBACK


### PR DESCRIPTION
The margins were going a bit wrong on displays with heavily rounded corners, e.g. C2. On fixed keyboard mode there was a gap between terminal and keyboard, and with moving keyboard mode the terminal had a small overlap with the virtual keyboard.

Some cleanups again here while at it.
