### PR TITLE
[fingerterm] Fix pixel ratio calculation on landscape displays. JB#62953

### DIFF
--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -18,8 +18,8 @@
 */
 
 import QtQuick 2.0
-import FingerTerm 1.0
 import QtQuick.Window 2.0
+import FingerTerm 1.0
 
 Item {
     id: root
@@ -81,7 +81,7 @@ Item {
 
             property int fadeOutTime: 80
             property int fadeInTime: 350
-            property real pixelRatio: root.width / 540
+            property real pixelRatio: root.width / (Screen.primaryOrientation === Qt.PortraitOrientation ? 540 : 960)
 
             // layout constants
             property int buttonWidthSmall: 60*pixelRatio


### PR DESCRIPTION
Base setup is for portrait device. On default landscape display the calculation resulted in too big pixel ratio and oversized content.